### PR TITLE
LORE-184 Add missing release plugin version variable to POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@ License is distributed along with this program and can be found at
     <fabric8.docker.plugin.version>0.30.0</fabric8.docker.plugin.version>
     <javadoc-plugin.version>3.1.0</javadoc-plugin.version>
     <source-plugin.version>3.0.1</source-plugin.version>
+    <release-plugin.version>2.5.3</release-plugin.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
#### What does this PR do?
Adds a missing variable to the POM for the Maven release plugin version.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
 @cjlange 
 @josephthweatt 

#### How should this be tested? (List steps with links to updated documentation)

#### Any background context you want to provide?

#### What are the relevant tickets?
Related to LORE-184

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
